### PR TITLE
Add support for filter by name prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This has the following fields:
   * **Path** - the hierarchy for the parameters
   * **Recursive** - whether to retrieve all parameters within a hierarchy
   * **Naming** - whether the environment variable should be **basename**, **relative** or **absolute**
+  * **Name Prefixes** - Filter parameters by comma separated name prefixes
 
 ## Pipelines
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   </parent>
 
   <artifactId>aws-parameter-store</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>AWS Parameter Store Build Wrapper</name>

--- a/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
+++ b/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
@@ -67,6 +67,7 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
   private final String path;
   private final Boolean recursive;
   private final String naming;
+  private final String namePrefixes;
 
   private transient AwsParameterStoreService parameterStoreService;
 
@@ -78,14 +79,16 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
    * @param path            hierarchy for the parameter
    * @param recursive       fetch all parameters within a hierarchy
    * @param naming          environment variable naming: basename, absolute, relative
+   * @param namePrefixes  filter parameters by Name with beginsWith filter
    */
   @DataBoundConstructor
-  public AwsParameterStoreBuildWrapper(String credentialsId, String regionName, String path, Boolean recursive, String naming) {
+  public AwsParameterStoreBuildWrapper(String credentialsId, String regionName, String path, Boolean recursive, String naming, String namePrefixes) {
     this.credentialsId = credentialsId;
     this.regionName = regionName;
     this.path = path;
     this.recursive = recursive;
     this.naming = naming;
+    this.namePrefixes = namePrefixes;
   }
 
   /**
@@ -128,10 +131,18 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
     return naming;
   }
 
+  /**
+   * Gets namePrefixes (comma separated)
+   * @return namePrefixes.
+   */
+  public String getNamePrefixes() {
+    return namePrefixes;
+  }
+
   @Override
   public void setUp(Context context, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
     AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, regionName);
-    awsParameterStoreService.buildEnvVars(context, path, recursive, naming);
+    awsParameterStoreService.buildEnvVars(context, path, recursive, naming, namePrefixes);
   }
 
   /**

--- a/src/main/resources/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper/config.jelly
@@ -39,5 +39,8 @@
     <f:entry title="${%Naming}" field="naming" description="Environment variable naming (basename|relative|absolute)">
       <f:select value="${it.naming}"/>
     </f:entry>
+    <f:entry title="${%Name Prefixes}" field="namePrefixes" description="Comma separated name prefixes used to filter parameter by name">
+      <f:textbox value="${it.namePrefixes}"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
@@ -90,6 +90,13 @@ public class AwsParameterStoreBuildWrapperTest {
           CREDENTIALS_AWS_NO_DESCRIBE,
           "relative",
           ""
+        },
+        {
+          null,
+          false,
+          CREDENTIALS_AWS_NO_DESCRIBE,
+          "",
+          "name_prefix"
         }
       }
     );

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
@@ -69,6 +69,9 @@ public class AwsParameterStoreBuildWrapperTest {
   public String credentialsId;
   @Parameter(3)
   public String naming;
+  @Parameter(4)
+  public String namePrefixes;
+
 
   @Parameters
   public static Collection<Object[]> data() {
@@ -78,13 +81,15 @@ public class AwsParameterStoreBuildWrapperTest {
           "/service/",
           false,
           CREDENTIALS_AWS_ADMIN,
-          "basename"
+          "basename",
+          ""
         },
         {
           null,
           true,
           CREDENTIALS_AWS_NO_DESCRIBE,
-          "relative"
+          "relative",
+          ""
         }
       }
     );
@@ -103,12 +108,13 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testConstructor() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
     Assert.assertEquals("credentialsId", credentialsId, awsParameterStoreBuildWrapper.getCredentialsId());
     Assert.assertEquals("regionName", REGION_NAME, awsParameterStoreBuildWrapper.getRegionName());
     Assert.assertEquals("path", path, awsParameterStoreBuildWrapper.getPath());
     Assert.assertEquals("recursive", recursive, awsParameterStoreBuildWrapper.getRecursive());
     Assert.assertEquals("naming", naming, awsParameterStoreBuildWrapper.getNaming());
+    Assert.assertEquals("namePrefixes", namePrefixes, awsParameterStoreBuildWrapper.getNamePrefixes());
   }
 
   /**
@@ -116,7 +122,7 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testSetup() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
     try {
       awsParameterStoreBuildWrapper.setUp((SimpleBuildWrapper.Context)null, null, null, null, null, null);
     } catch(Exception e) {

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
@@ -98,8 +98,10 @@ public class AwsParameterStoreServiceTest {
   @Parameter(3)
   public String naming;
   @Parameter(4)
-  public String[][] expected;
+  public String namePrefixes;
   @Parameter(5)
+  public String[][] expected;
+  @Parameter(6)
   public String credentialsId;
 
   @Parameters
@@ -111,6 +113,7 @@ public class AwsParameterStoreServiceTest {
           null,
           false,
           "basename",
+          "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -119,6 +122,7 @@ public class AwsParameterStoreServiceTest {
           null,
           false,
           "basename",
+          "",
           new String[][] { { "_X___TEST", "value1" }, { "123ABCD", "value2" }, { "NAME3", "value3" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -127,6 +131,7 @@ public class AwsParameterStoreServiceTest {
           "/service/",
           true,
           null,
+          "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -135,6 +140,7 @@ public class AwsParameterStoreServiceTest {
           "/service/",
           true,
           "basename",
+          "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -143,6 +149,7 @@ public class AwsParameterStoreServiceTest {
           "/service",
           true,
           "basename",
+          "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -151,6 +158,7 @@ public class AwsParameterStoreServiceTest {
           "/service/",
           true,
           "absolute",
+          "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -159,6 +167,7 @@ public class AwsParameterStoreServiceTest {
           "/service",
           true,
           "absolute",
+          "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -167,6 +176,7 @@ public class AwsParameterStoreServiceTest {
           "/service/",
           true,
           "relative",
+          "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -175,6 +185,7 @@ public class AwsParameterStoreServiceTest {
           "/service",
           true,
           "relative",
+          "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -183,6 +194,7 @@ public class AwsParameterStoreServiceTest {
           null,
           false,
           "basename",
+          "",
           new String[][] { { "NAME1", "" }, { "NAME2", null }, { "NAME3", "value3" } },
           CREDENTIALS_AWS_ADMIN
         },
@@ -191,6 +203,7 @@ public class AwsParameterStoreServiceTest {
           null,
           false,
           "basename",
+          "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
           CREDENTIALS_AWS_NO_DESCRIBE
         },
@@ -199,6 +212,7 @@ public class AwsParameterStoreServiceTest {
           null,
           false,
           "basename",
+          "",
           new String[][] { { "NAME1", null }, { "NAME2", "value2" } },
           CREDENTIALS_AWS_NO_GET
         },
@@ -207,6 +221,7 @@ public class AwsParameterStoreServiceTest {
           "/service/",
           true,
           "basename",
+          "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
           CREDENTIALS_AWS_NO_GETBYPATH
         }
@@ -240,7 +255,7 @@ public class AwsParameterStoreServiceTest {
   public void testBuildEnvVars() {
     SimpleBuildWrapper.Context context = new SimpleBuildWrapper.Context();
     AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, REGION_NAME);
-    awsParameterStoreService.buildEnvVars(context, path, recursive, naming);
+    awsParameterStoreService.buildEnvVars(context, path, recursive, naming, namePrefixes);
     for(int i = 0; i < expected.length; i++) {
       Assert.assertEquals(parameters[i][NAME], expected[i][VALUE], context.getEnv().get(expected[i][NAME]));
     }

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
@@ -189,6 +189,33 @@ public class AwsParameterStoreServiceTest {
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
           CREDENTIALS_AWS_ADMIN
         },
+        { /* namePrefixes = single exact value */
+          new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
+          null,
+          false,
+          null,
+          "prefix1_name1",
+          new String[][] { { "PREFIX1_NAME1", "value1" } },
+          CREDENTIALS_AWS_ADMIN
+        },
+        { /* namePrefixes = single prefix value */
+          new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
+          null,
+          false,
+          null,
+          "prefix",
+          new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
+          CREDENTIALS_AWS_ADMIN
+        },
+        { /* namePrefixes = comma separated multi prefix value */
+          new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
+          null,
+          false,
+          null,
+          "prefix1,prefix2_name2",
+          new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
+          CREDENTIALS_AWS_ADMIN
+        },
         { /* empty values */
           new String[][] { { "name1", "" }, { "name2", null }, { "name3","value3" } },
           null,
@@ -332,11 +359,27 @@ public class AwsParameterStoreServiceTest {
     List<com.amazonaws.services.simplesystemsmanagement.model.Parameter> params =
                  new ArrayList<com.amazonaws.services.simplesystemsmanagement.model.Parameter>();
     for(int i = 0; i < parameters.length; i++) {
-      if(StringUtils.isEmpty(path) || parameters[i][NAME].startsWith(path)) {
-        params.add(new com.amazonaws.services.simplesystemsmanagement.model.Parameter().withName(parameters[i][NAME]).withValue(parameters[i][VALUE]));
+      String parameterName = parameters[i][NAME];
+      if(isMatchedByNamePrefixes(parameterName) || StringUtils.isEmpty(path) || parameterName.startsWith(path)) {
+        params.add(new com.amazonaws.services.simplesystemsmanagement.model.Parameter().withName(parameterName).withValue(parameters[i][VALUE]));
       }
     }
     return params;
+  }
+
+  /**
+   * Simulate match parameter name by prefixes
+   */
+  private boolean isMatchedByNamePrefixes(String parameterName) {
+    if (StringUtils.isEmpty(namePrefixes)) {
+      return false;
+    }
+    for (String namePrefix :  namePrefixes.split(",")) {
+      if (parameterName.startsWith(namePrefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
hi, @rikturnbull , we have a little bit issue with using the `path` to load our target environment variable from parameter store. The main issue is that we only want to load only a small subset of parameters from the root level, using the `path` option ended up loading all parameters. 

We'd like to add a small support to filter by one or more parameter name prefixes. e.g. 

with the following records in the parameter store:

```
jwt_token_secret
jwt_token_expiry
db_secret
http_token
``` 

given following `namePrefixes` input:

```
jwt_token,http_token
```

it then loads the following:

```
jwt_token_secret
jwt_token_expiry
http_token
```
