### PR TITLE
Allow custom AWS credentials via pipeline environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 work
+.m2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.6'
+services:
+  build:
+    image: maven:3-ibmjava-8
+    entrypoint: mvn package
+    volumes:
+      - .:/build
+      - .m2:/root/.m2
+    working_dir: /build
+
+  test:
+    image: maven:3-ibmjava-8
+    entrypoint: mvn test
+    volumes:
+      - .:/build
+      - .m2:/root/.m2
+    working_dir: /build

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   </parent>
 
   <artifactId>aws-parameter-store</artifactId>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.2.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>AWS Parameter Store Build Wrapper</name>

--- a/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
+++ b/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
@@ -71,6 +71,9 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
   private Boolean recursive;
   private String naming;
   private String namePrefixes;
+  private String accessKeyId;
+  private String secretAccessKey;
+  private String sessionToken;
 
   private transient AwsParameterStoreService parameterStoreService;
 
@@ -79,7 +82,7 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
    */
   @DataBoundConstructor
   public AwsParameterStoreBuildWrapper() {
-    this(null, null, null, false, null, null);
+    this(null, null, null, false, null, null, null, null, null);
   }
 
   /**
@@ -91,15 +94,30 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
    * @param recursive       fetch all parameters within a hierarchy
    * @param naming          environment variable naming: basename, absolute, relative
    * @param namePrefixes    filter parameters by Name with beginsWith filter
+   * @param accessKeyId     AWS access key ID
+   * @param secretAccessKey AWS secret access key
+   * @param sessionToken    AWS session token
    */
   @Deprecated
-  public AwsParameterStoreBuildWrapper(String credentialsId, String regionName, String path, Boolean recursive, String naming, String namePrefixes) {
+  public AwsParameterStoreBuildWrapper(
+      String credentialsId,
+      String regionName,
+      String path,
+      Boolean recursive,
+      String naming,
+      String namePrefixes,
+      String accessKeyId,
+      String secretAccessKey,
+      String sessionToken) {
     this.credentialsId = credentialsId;
     this.regionName = regionName;
     this.path = path;
     this.recursive = recursive;
     this.naming = naming;
     this.namePrefixes = namePrefixes;
+    this.accessKeyId = accessKeyId;
+    this.secretAccessKey = secretAccessKey;
+    this.sessionToken = sessionToken;
   }
 
   /**
@@ -210,9 +228,63 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
     this.namePrefixes = StringUtils.stripToNull(namePrefixes);
   }
 
+  /**
+   * Gets Access key ID
+   * @return accessKeyId.
+   */
+  public String getAccessKeyId() {
+    return accessKeyId;
+  }
+
+  /**
+   * Sets the AWS access key ID
+   *
+   * @param accessKeyId  the AWS access key ID
+   */
+  @DataBoundSetter
+  public void setAccessKeyId(String accessKeyId) {
+    this.accessKeyId = StringUtils.stripToNull(accessKeyId);
+  }
+
+  /**
+   * Gets Secret access key
+   * @return secretAccessKey.
+   */
+  public String getSecretAccessKey() {
+    return secretAccessKey;
+  }
+
+  /**
+   * Sets the AWS secret access key
+   *
+   * @param secretAccessKey  the AWS secret access key
+   */
+  @DataBoundSetter
+  public void setSecretAccessKey(String secretAccessKey) {
+    this.secretAccessKey = StringUtils.stripToNull(secretAccessKey);
+  }
+
+  /**
+   * Gets session token
+   * @return sessionToken.
+   */
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  /**
+   * Sets the AWS session token
+   *
+   * @param sessionToken  the AWS session token
+   */
+  @DataBoundSetter
+  public void setSessionToken(String sessionToken) {
+    this.sessionToken = StringUtils.stripToNull(sessionToken);
+  }
+
   @Override
   public void setUp(Context context, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
-    AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, regionName);
+    AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, regionName, accessKeyId, secretAccessKey, sessionToken);
     awsParameterStoreService.buildEnvVars(context, path, recursive, naming, namePrefixes);
   }
 

--- a/src/main/resources/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper/help-credentialsId.html
+++ b/src/main/resources/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper/help-credentialsId.html
@@ -1,1 +1,1 @@
-AWS credentials used for accessing AWS Parameter Store. If set to <tt>--none--</tt>, uses the default credentials provider chain to search for credentials in the environment, file system or associated IAM role.
+AWS credentials used for accessing AWS Parameter Store. If set to <tt>--none--</tt>, uses the default credentials provider chain to search for credentials in the environment, file system or associated IAM role. Note: environment variables set via the pipeline are not honored. Instead, use the accessKeyId, secretAccessKey, and optionally sessionToken parameters.

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
@@ -73,7 +73,12 @@ public class AwsParameterStoreBuildWrapperTest {
   public String naming;
   @Parameter(4)
   public String namePrefixes;
-
+  @Parameter(5)
+  public String accessKeyId;
+  @Parameter(6)
+  public String secretAccessKey;
+  @Parameter(7)
+  public String sessionToken;
 
   @Parameters
   public static Collection<Object[]> data() {
@@ -84,6 +89,9 @@ public class AwsParameterStoreBuildWrapperTest {
           false,
           CREDENTIALS_AWS_ADMIN,
           "basename",
+          "",
+          "",
+          "",
           ""
         },
         {
@@ -91,6 +99,9 @@ public class AwsParameterStoreBuildWrapperTest {
           true,
           CREDENTIALS_AWS_NO_DESCRIBE,
           "relative",
+          "",
+          "",
+          "",
           ""
         },
         {
@@ -98,7 +109,10 @@ public class AwsParameterStoreBuildWrapperTest {
           false,
           CREDENTIALS_AWS_NO_DESCRIBE,
           "",
-          "name_prefix"
+          "name_prefix",
+          "",
+          "",
+          ""
         }
       }
     );
@@ -117,13 +131,25 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testConstructor() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(
+      credentialsId,
+      REGION_NAME,
+      path,
+      recursive,
+      naming,
+      namePrefixes,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken);
     Assert.assertEquals("credentialsId", credentialsId, awsParameterStoreBuildWrapper.getCredentialsId());
     Assert.assertEquals("regionName", REGION_NAME, awsParameterStoreBuildWrapper.getRegionName());
     Assert.assertEquals("path", path, awsParameterStoreBuildWrapper.getPath());
     Assert.assertEquals("recursive", recursive, awsParameterStoreBuildWrapper.getRecursive());
     Assert.assertEquals("naming", naming, awsParameterStoreBuildWrapper.getNaming());
     Assert.assertEquals("namePrefixes", namePrefixes, awsParameterStoreBuildWrapper.getNamePrefixes());
+    Assert.assertEquals("accessKeyId", accessKeyId, awsParameterStoreBuildWrapper.getAccessKeyId());
+    Assert.assertEquals("secretAccessKey", secretAccessKey, awsParameterStoreBuildWrapper.getSecretAccessKey());
+    Assert.assertEquals("sessionToken", sessionToken, awsParameterStoreBuildWrapper.getSessionToken());
   }
 
   /**
@@ -138,6 +164,9 @@ public class AwsParameterStoreBuildWrapperTest {
     awsParameterStoreBuildWrapper.setRecursive(recursive);
     awsParameterStoreBuildWrapper.setNaming(naming);
     awsParameterStoreBuildWrapper.setNamePrefixes(namePrefixes);
+    awsParameterStoreBuildWrapper.setAccessKeyId(accessKeyId);
+    awsParameterStoreBuildWrapper.setSecretAccessKey(secretAccessKey);
+    awsParameterStoreBuildWrapper.setSessionToken(sessionToken);
 
     Assert.assertEquals("credentialsId", credentialsId, awsParameterStoreBuildWrapper.getCredentialsId());
     Assert.assertEquals("regionName", REGION_NAME, awsParameterStoreBuildWrapper.getRegionName());
@@ -145,6 +174,9 @@ public class AwsParameterStoreBuildWrapperTest {
     Assert.assertEquals("recursive", recursive, awsParameterStoreBuildWrapper.getRecursive());
     Assert.assertEquals("naming", naming, awsParameterStoreBuildWrapper.getNaming());
     Assert.assertEquals("namePrefixes", StringUtils.stripToNull(namePrefixes), awsParameterStoreBuildWrapper.getNamePrefixes());
+    Assert.assertEquals("accessKeyId", StringUtils.stripToNull(accessKeyId), awsParameterStoreBuildWrapper.getAccessKeyId());
+    Assert.assertEquals("secretAccessKey", StringUtils.stripToNull(secretAccessKey), awsParameterStoreBuildWrapper.getSecretAccessKey());
+    Assert.assertEquals("sessionToken", StringUtils.stripToNull(sessionToken), awsParameterStoreBuildWrapper.getSessionToken());
   }
 
   /**
@@ -152,7 +184,16 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testSetup() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(
+      credentialsId,
+      REGION_NAME,
+      path,
+      recursive,
+      naming,
+      namePrefixes,
+      accessKeyId,
+      secretAccessKey,
+      sessionToken);
     try {
       awsParameterStoreBuildWrapper.setUp((SimpleBuildWrapper.Context)null, null, null, null, null, null);
     } catch(Exception e) {

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
@@ -23,6 +23,7 @@
   */
 package hudson.plugins.awsparameterstore;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
@@ -103,6 +104,12 @@ public class AwsParameterStoreServiceTest {
   public String[][] expected;
   @Parameter(6)
   public String credentialsId;
+  @Parameter(7)
+  public String accessKeyId;
+  @Parameter(8)
+  public String secretAccessKey;
+  @Parameter(9)
+  public String sessionToken;
 
   @Parameters
   public static Collection<Object[]> data() {
@@ -115,7 +122,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* non-alphanumerics */
           new String[][] { { "*X()_test", "value1" }, { "123abCD", "value2" }, { "name3","value3" } },
@@ -124,7 +134,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "_X___TEST", "value1" }, { "123ABCD", "value2" }, { "NAME3", "value3" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = null test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -133,7 +146,10 @@ public class AwsParameterStoreServiceTest {
           null,
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = basename test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -142,7 +158,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = basename test - no trailing '/'*/
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -151,7 +170,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = absolute test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" } },
@@ -160,7 +182,10 @@ public class AwsParameterStoreServiceTest {
           "absolute",
           "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = absolute test - no trailing '/' */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" } },
@@ -169,7 +194,10 @@ public class AwsParameterStoreServiceTest {
           "absolute",
           "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = relative test */
           new String[][] { { "/service/app/name1", "value1" }, { "/service/name2", "value2" } },
@@ -178,7 +206,10 @@ public class AwsParameterStoreServiceTest {
           "relative",
           "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* naming = relative test - no trailing '/' */
           new String[][] { { "/service/app/name1", "value1" }, { "/service/name2", "value2" } },
@@ -187,7 +218,10 @@ public class AwsParameterStoreServiceTest {
           "relative",
           "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* namePrefixes = single exact value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -196,7 +230,10 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix1_name1",
           new String[][] { { "PREFIX1_NAME1", "value1" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* namePrefixes = single prefix value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -205,7 +242,10 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix",
           new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* namePrefixes = comma separated multi prefix value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -214,7 +254,10 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix1,prefix2_name2",
           new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* empty values */
           new String[][] { { "name1", "" }, { "name2", null }, { "name3","value3" } },
@@ -223,7 +266,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "" }, { "NAME2", null }, { "NAME3", "value3" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          "",
+          "",
+          ""
         },
         { /* no describe */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -232,7 +278,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
-          CREDENTIALS_AWS_NO_DESCRIBE
+          CREDENTIALS_AWS_NO_DESCRIBE,
+          "",
+          "",
+          ""
         },
         { /* no get-parameter */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -241,7 +290,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_NO_GET
+          CREDENTIALS_AWS_NO_GET,
+          "",
+          "",
+          ""
         },
         { /* no get-parameter-by-path */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -250,7 +302,10 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
-          CREDENTIALS_AWS_NO_GETBYPATH
+          CREDENTIALS_AWS_NO_GETBYPATH,
+          "",
+          "",
+          ""
         }
       }
     );
@@ -271,7 +326,7 @@ public class AwsParameterStoreServiceTest {
    */
   @Test
   public void testConstructor() {
-    new AwsParameterStoreService(credentialsId, REGION_NAME);
+    new AwsParameterStoreService(credentialsId, REGION_NAME, accessKeyId, secretAccessKey, sessionToken);
   }
 
   /**
@@ -281,7 +336,7 @@ public class AwsParameterStoreServiceTest {
   @Test
   public void testBuildEnvVars() {
     SimpleBuildWrapper.Context context = new SimpleBuildWrapper.Context();
-    AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, REGION_NAME);
+    AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, REGION_NAME, accessKeyId, secretAccessKey, sessionToken);
     awsParameterStoreService.buildEnvVars(context, path, recursive, naming, namePrefixes);
     for(int i = 0; i < expected.length; i++) {
       Assert.assertEquals(parameters[i][NAME], expected[i][VALUE], context.getEnv().get(expected[i][NAME]));


### PR DESCRIPTION
During pipeline execution, if you set environment variables via the example below, the environment variables are not used by the plugin. This is expected behavior I _think_ with how Jenkins plugins operate.

```
script {
  env.AWS_ACCESS_KEY_ID = "123"
}
```

To get around this, I have added 3 additional arguments to the pipeline:
- accessKeyId
- secretAccessKey
- sessionToken (optional).

Now I can use the plugin like this (note: the assumeRole function sets the env variables):
```
script {
          withAWSParameterStore(namePrefixes: '/shared/ASSUME_ROLE_ARNS,/shared/CFN_TEMPLATE_BUCKET', regionName: env.AWS_REGION) {
            env.TEMPLATE_BUCKET = env.SHARED_CFN_TEMPLATE_BUCKET
            assumeRole()
            withAWSParameterStore(namePrefixes: '/xxx/DB_HOST', regionName: env.AWS_REGION, accessKeyId: env.AWS_ACCESS_KEY_ID, secretAccessKey: env.AWS_SECRET_ACCESS_KEY, sessionToken: env.AWS_SESSION_TOKEN) {
              sh 'env | sort'
            }
          }
        }
```

I'm sure my use case is not unique. In my pipeline, Jenkins assumes roles into target accounts for dev/prod/etc. I am unable to use this plugin to then lookup SSM parameters in the target account and have been using alternate methods. It'd be good to get this integrated.

Oh, I have also added a docker-compose file to allow easy building and testing locally.