### PR TITLE
Add parameter to fetch parameters by exact name

### DIFF
--- a/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
+++ b/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapper.java
@@ -72,6 +72,7 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
   private Boolean recursive;
   private String naming;
   private String namePrefixes;
+  private Boolean exactNames;
 
   private transient AwsParameterStoreService parameterStoreService;
 
@@ -80,7 +81,7 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
    */
   @DataBoundConstructor
   public AwsParameterStoreBuildWrapper() {
-    this(null, null, null, false, null, null);
+    this(null, null, null, false, null, null, false);
   }
 
   /**
@@ -92,15 +93,17 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
    * @param recursive       fetch all parameters within a hierarchy
    * @param naming          environment variable naming: basename, absolute, relative
    * @param namePrefixes    filter parameters by Name with beginsWith filter
+   * @param exactNames      Whether name prefixes should be treated as exact parameter names
    */
   @Deprecated
-  public AwsParameterStoreBuildWrapper(String credentialsId, String regionName, String path, Boolean recursive, String naming, String namePrefixes) {
+  public AwsParameterStoreBuildWrapper(String credentialsId, String regionName, String path, Boolean recursive, String naming, String namePrefixes, Boolean exactNames) {
     this.credentialsId = credentialsId;
     this.regionName = regionName;
     this.path = path;
     this.recursive = recursive;
     this.naming = naming;
     this.namePrefixes = namePrefixes;
+    this.exactNames = exactNames;
   }
 
   /**
@@ -202,6 +205,24 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
   }
 
   /**
+   * Gets exactNames flag.
+   * @return exactNames
+   */
+  public Boolean getExactNames() {
+    return exactNames;
+  }
+
+  /**
+   * Sets the exactNames flag.
+   *
+   * @param exactNames  exact names flag
+   */
+  @DataBoundSetter
+  public void setExactNames(Boolean exactNames) {
+    this.exactNames = exactNames;
+  }
+
+  /**
    * Sets the name prefixes filter.
    *
    * @param namePrefixes  name prefixes filter
@@ -214,7 +235,7 @@ public class AwsParameterStoreBuildWrapper extends SimpleBuildWrapper {
   @Override
   public void setUp(Context context, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment) throws IOException, InterruptedException {
     AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, regionName);
-    awsParameterStoreService.buildEnvVars(context, initialEnvironment, path, recursive, naming, namePrefixes);
+    awsParameterStoreService.buildEnvVars(context, initialEnvironment, path, recursive, naming, namePrefixes, exactNames);
   }
 
   /**

--- a/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreService.java
+++ b/src/main/java/hudson/plugins/awsparameterstore/AwsParameterStoreService.java
@@ -65,7 +65,6 @@ import org.apache.commons.lang.StringUtils;
  * AWS Parameter Store client.
  *
  * @author Rik Turnbull
- *
  */
 public class AwsParameterStoreService {
   public static final String DEFAULT_REGION = "us-east-1";
@@ -225,10 +224,10 @@ public class AwsParameterStoreService {
       try {
         String envVarName = toEnvironmentVariable(name, getParameterPath(name), naming);
 
-        String value = client
-          .getParameter(getParameterRequest)
-          .getParameter()
-          .getValue();
+        String value = client.
+                        getParameter(getParameterRequest).
+                        getParameter().
+                        getValue();
 
         context.env(envVarName, value);
       } catch(Exception e) {
@@ -251,10 +250,10 @@ public class AwsParameterStoreService {
       DescribeParametersRequest describeParametersRequest = new DescribeParametersRequest().withMaxResults(1);
       if (!StringUtils.isEmpty(namePrefixes)) {
         describeParametersRequest = describeParametersRequest.withParameterFilters(
-          new ParameterStringFilter()
-            .withKey("Name")
-            .withOption("BeginsWith")
-            .withValues(namePrefixes.split(","))
+          new ParameterStringFilter().
+            withKey("Name").
+            withOption("BeginsWith").
+            withValues(namePrefixes.split(","))
         );
       }
 
@@ -287,10 +286,11 @@ public class AwsParameterStoreService {
     LOGGER.log(Level.INFO, "Fetching all parameters by path: \"" + path + "\"");
 
     try {
-      final GetParametersByPathRequest getParametersByPathRequest = new GetParametersByPathRequest()
-        .withPath(path)
-        .withRecursive(recursive)
-        .withWithDecryption(true);
+      final GetParametersByPathRequest getParametersByPathRequest =
+        new GetParametersByPathRequest().
+              withPath(path).
+              withRecursive(recursive).
+              withWithDecryption(true);
 
       do {
         final GetParametersByPathResult getParametersByPathResult = client.getParametersByPath(getParametersByPathRequest);

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreBuildWrapperTest.java
@@ -73,7 +73,8 @@ public class AwsParameterStoreBuildWrapperTest {
   public String naming;
   @Parameter(4)
   public String namePrefixes;
-
+  @Parameter(5)
+  public Boolean exactNames;
 
   @Parameters
   public static Collection<Object[]> data() {
@@ -84,21 +85,24 @@ public class AwsParameterStoreBuildWrapperTest {
           false,
           CREDENTIALS_AWS_ADMIN,
           "basename",
-          ""
+          "",
+          false
         },
         {
           null,
           true,
           CREDENTIALS_AWS_NO_DESCRIBE,
           "relative",
-          ""
+          "",
+          false
         },
         {
           null,
           false,
           CREDENTIALS_AWS_NO_DESCRIBE,
           "",
-          "name_prefix"
+          "name_prefix",
+          false
         }
       }
     );
@@ -117,13 +121,14 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testConstructor() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes, exactNames);
     Assert.assertEquals("credentialsId", credentialsId, awsParameterStoreBuildWrapper.getCredentialsId());
     Assert.assertEquals("regionName", REGION_NAME, awsParameterStoreBuildWrapper.getRegionName());
     Assert.assertEquals("path", path, awsParameterStoreBuildWrapper.getPath());
     Assert.assertEquals("recursive", recursive, awsParameterStoreBuildWrapper.getRecursive());
     Assert.assertEquals("naming", naming, awsParameterStoreBuildWrapper.getNaming());
     Assert.assertEquals("namePrefixes", namePrefixes, awsParameterStoreBuildWrapper.getNamePrefixes());
+    Assert.assertEquals("exactNames", exactNames, awsParameterStoreBuildWrapper.getExactNames());
   }
 
   /**
@@ -145,6 +150,7 @@ public class AwsParameterStoreBuildWrapperTest {
     Assert.assertEquals("recursive", recursive, awsParameterStoreBuildWrapper.getRecursive());
     Assert.assertEquals("naming", naming, awsParameterStoreBuildWrapper.getNaming());
     Assert.assertEquals("namePrefixes", StringUtils.stripToNull(namePrefixes), awsParameterStoreBuildWrapper.getNamePrefixes());
+    Assert.assertEquals("exactNames", exactNames, awsParameterStoreBuildWrapper.getExactNames());
   }
 
   /**
@@ -152,7 +158,7 @@ public class AwsParameterStoreBuildWrapperTest {
    */
   @Test
   public void testSetup() {
-    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes);
+    AwsParameterStoreBuildWrapper awsParameterStoreBuildWrapper = new AwsParameterStoreBuildWrapper(credentialsId, REGION_NAME, path, recursive, naming, namePrefixes, exactNames);
     try {
       awsParameterStoreBuildWrapper.setUp((SimpleBuildWrapper.Context)null, null, null, null, null, null);
     } catch(Exception e) {

--- a/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
+++ b/src/test/java/hudson/plugins/awsparameterstore/AwsParameterStoreServiceTest.java
@@ -104,6 +104,8 @@ public class AwsParameterStoreServiceTest {
   public String[][] expected;
   @Parameter(6)
   public String credentialsId;
+  @Parameter(7)
+  public Boolean exactNames;
 
   @Parameters
   public static Collection<Object[]> data() {
@@ -116,7 +118,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* non-alphanumerics */
           new String[][] { { "*X()_test", "value1" }, { "123abCD", "value2" }, { "name3","value3" } },
@@ -125,7 +128,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "_X___TEST", "value1" }, { "123ABCD", "value2" }, { "NAME3", "value3" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = null test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -134,7 +138,8 @@ public class AwsParameterStoreServiceTest {
           null,
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = basename test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -143,7 +148,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = basename test - no trailing '/'*/
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" }, {"/ignore/name3", "value3"} },
@@ -152,7 +158,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" }, { "NAME3", null } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = absolute test */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" } },
@@ -161,7 +168,8 @@ public class AwsParameterStoreServiceTest {
           "absolute",
           "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = absolute test - no trailing '/' */
           new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" } },
@@ -170,7 +178,8 @@ public class AwsParameterStoreServiceTest {
           "absolute",
           "",
           new String[][] { { "SERVICE_NAME1", "value1" }, { "SERVICE_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = relative test */
           new String[][] { { "/service/app/name1", "value1" }, { "/service/name2", "value2" } },
@@ -179,7 +188,8 @@ public class AwsParameterStoreServiceTest {
           "relative",
           "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* naming = relative test - no trailing '/' */
           new String[][] { { "/service/app/name1", "value1" }, { "/service/name2", "value2" } },
@@ -188,7 +198,8 @@ public class AwsParameterStoreServiceTest {
           "relative",
           "",
           new String[][] { { "APP_NAME1", "value1" }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* namePrefixes = single exact value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -197,7 +208,8 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix1_name1",
           new String[][] { { "PREFIX1_NAME1", "value1" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* namePrefixes = single prefix value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -206,7 +218,8 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix",
           new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* namePrefixes = comma separated multi prefix value */
           new String[][] { { "prefix1_name1", "value1" }, { "prefix2_name2", "value2" } },
@@ -215,7 +228,18 @@ public class AwsParameterStoreServiceTest {
           null,
           "prefix1,prefix2_name2",
           new String[][] { { "PREFIX1_NAME1", "value1" }, { "PREFIX2_NAME2", "value2" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
+        },
+        { /* exactNames = true */
+          new String[][] { { "/service/name1", "value1" }, { "/service/name2", "value2" } },
+          null,
+          false,
+          "basename",
+          "/service/name1,/service/name2",
+          new String[][] { { "NAME1", "value1" }, { "NAME2", "value2" } },
+          CREDENTIALS_AWS_ADMIN,
+          true
         },
         { /* empty values */
           new String[][] { { "name1", "" }, { "name2", null }, { "name3","value3" } },
@@ -224,7 +248,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", "" }, { "NAME2", null }, { "NAME3", "value3" } },
-          CREDENTIALS_AWS_ADMIN
+          CREDENTIALS_AWS_ADMIN,
+          false
         },
         { /* no describe */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -233,7 +258,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
-          CREDENTIALS_AWS_NO_DESCRIBE
+          CREDENTIALS_AWS_NO_DESCRIBE,
+          false
         },
         { /* no get-parameter */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -242,7 +268,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", "value2" } },
-          CREDENTIALS_AWS_NO_GET
+          CREDENTIALS_AWS_NO_GET,
+          false
         },
         { /* no get-parameter-by-path */
           new String[][] { { "name1", "value1" }, { "name2", "value2" } },
@@ -251,7 +278,8 @@ public class AwsParameterStoreServiceTest {
           "basename",
           "",
           new String[][] { { "NAME1", null }, { "NAME2", null } },
-          CREDENTIALS_AWS_NO_GETBYPATH
+          CREDENTIALS_AWS_NO_GETBYPATH,
+          false
         }
       }
     );
@@ -283,7 +311,7 @@ public class AwsParameterStoreServiceTest {
   public void testBuildEnvVars() {
     SimpleBuildWrapper.Context context = new SimpleBuildWrapper.Context();
     AwsParameterStoreService awsParameterStoreService = new AwsParameterStoreService(credentialsId, REGION_NAME);
-    awsParameterStoreService.buildEnvVars(context, new EnvVars(), path, recursive, naming, namePrefixes);
+    awsParameterStoreService.buildEnvVars(context, new EnvVars(), path, recursive, naming, namePrefixes, exactNames);
     for(int i = 0; i < expected.length; i++) {
       Assert.assertEquals(parameters[i][NAME], expected[i][VALUE], context.getEnv().get(expected[i][NAME]));
     }


### PR DESCRIPTION
Adds `exactNames` parameter to treat `path` as an exact parameter name to be fetched from the ParameterStore.

It is very convenient to be able to fetch all parameters that start with `app/env/AWS_` prefix for example but sometimes we want to make sure that we're fetching exactly one parameter with exactly _this_ name. This is what this code change accomplishes.

### Changes
- `exactNames` boolean argument added
- `buildEnvVarsWithParameters` is broken up into two methods. Code that was fetching parameter names by path is extracted into its own function and is now called when `exactNames` is `false` (default behavior)

### Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
